### PR TITLE
Math signs and example of Exception implemented

### DIFF
--- a/src/Controller/CalculatorController.php
+++ b/src/Controller/CalculatorController.php
@@ -2,22 +2,39 @@
 
 namespace App\Controller;
 
+use App\Exception\MathSignException;
 use App\Service\CalculatorService;
 use InvalidArgumentException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 class CalculatorController extends AbstractController
 {
-    #[Route('/calculator/{numberOne}/{numberTwo}', name: 'calculator', methods: ['GET'])]
-    public function calc(int $numberOne, int $numberTwo): JsonResponse
+    public array $mathSigns = [
+        '+' => 'add',
+        '-' => 'sub',
+        '*' => 'mul',
+        '/' => 'div',
+    ];
+
+    public function __construct(private readonly CalculatorService $calculatorService)
     {
-        $calculator = new CalculatorService();
+    }
+
+    #[Route('/calculator/{numberOne}/{numberTwo}', name: 'calculator', methods: ['GET'])]
+    public function calc(int $numberOne, int $numberTwo, Request $request): JsonResponse
+    {
+        $mathSign = $request->get('mathSign') ?? '';
         try {
-            $result = $calculator->calculate($numberOne, $numberTwo);
-        } catch (InvalidArgumentException $exception) {
+            if (!array_key_exists($mathSign, $this->mathSigns)) {
+                throw new MathSignException($mathSign);
+            }
+
+            $result = $this->calculatorService->calculate($numberOne, $numberTwo, $this->mathSigns[$mathSign]);
+        } catch (InvalidArgumentException|MathSignException $exception) {
             return new JsonResponse(['error' => $exception->getMessage()], Response::HTTP_BAD_REQUEST);
         }
         return new JsonResponse($result, Response::HTTP_OK);

--- a/src/Exception/AbstractException.php
+++ b/src/Exception/AbstractException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Exception;
+
+use Exception;
+
+class  AbstractException extends Exception
+{
+    private string $errorCode;
+
+    public function __construct(string $message, string $errorCode, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+        $this->errorCode = $errorCode;
+    }
+}

--- a/src/Exception/MathSignException.php
+++ b/src/Exception/MathSignException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Exception;
+
+class MathSignException extends AbstractException
+{
+    private const string ERROR_DESCRIPTOR = 'MATH_SIGN_ERROR';
+    private const string MESSAGE = 'there are -, *, / and %%2B(instead +) allowed';
+
+    public function __construct(string $errorMessage, ?\Throwable $previous = null)
+    {
+        $message = sprintf('%s passed: %s', $errorMessage, self::MESSAGE);
+        parent::__construct($message, self::ERROR_DESCRIPTOR, $previous);
+    }
+}

--- a/src/Service/CalculatorService.php
+++ b/src/Service/CalculatorService.php
@@ -6,11 +6,32 @@ use InvalidArgumentException;
 
 class CalculatorService
 {
-    public static function calculate($numberOne, $numberTwo): int
+    private function calculateAdd(int $numberOne, int $numberTwo): int
+    {
+        return $numberOne + $numberTwo;
+    }
+
+    private function calculateSub(int $numberOne, int $numberTwo): int
+    {
+        return $numberOne - $numberTwo;
+    }
+
+    private function calculateMul(int $numberOne, int $numberTwo): int
+    {
+        return $numberOne * $numberTwo;
+    }
+
+    private function calculateDiv(int $numberOne, int $numberTwo): int
     {
         if ($numberTwo === 0) {
             throw new InvalidArgumentException('Division by zero');
         }
         return $numberOne / $numberTwo;
+    }
+
+    public function calculate(int $numberOne, int $numberTwo, string $mathSign): int
+    {
+        $actionName = 'calculate' . ucfirst($mathSign);
+        return $this->$actionName($numberOne, $numberTwo);
     }
 }


### PR DESCRIPTION
Math operations has been implemented, for instance:

![image](https://github.com/ssamko0911/symfony_calc/assets/24491919/7c03b746-8c39-4300-975e-756e54ac20d8)

![image](https://github.com/ssamko0911/symfony_calc/assets/24491919/9f43c5f4-6f6b-4b2f-92dd-c1a02b373935)

+ some exception handling example: 

![image](https://github.com/ssamko0911/symfony_calc/assets/24491919/fb5fa08e-c8a8-4f7d-943d-e17e7966b300)

Thanks! 